### PR TITLE
Update ICal.php

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -2154,7 +2154,7 @@ class ICal
      */
     protected function isFileOrUrl($filename)
     {
-        return (file_exists($filename) || filter_var($filename, FILTER_VALIDATE_URL)) ?: false;
+        return (@file_exists($filename) || filter_var($filename, FILTER_VALIDATE_URL)) ?: false;
     }
 
     /**


### PR DESCRIPTION
Suppress warning if the filename is too long

I got the following error:
`Warning: file_exists(): File name is longer than the maximum allowed path length on this platform (4096): BEGIN:VCALENDAR VERSION:2.0 PRODID:-//Nextcloud calendar v1.6.4 CALSCALE:GREGORIAN BEGIN:VTIMEZONE TZID:Europe/Zurich X-LIC-LOCATION:Europe/Zurich BEGIN:DAYLIGHT TZOFFSETFROM:+0100 TZOFFSETTO:+0200 TZNAME:CEST DTSTART:19700329T020000 RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU END:DAYLIGHT BEGIN:STANDARD TZOFFSETFROM:+0200 TZOFFSETTO:+0100 TZNAME:CET DTSTART:19701025T030000 RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU END:STANDARD END:VTIMEZONE BEGIN:VEVENT CREATED:20181202T235046 SUMMARY:*** LOCATION: STATUS:CONFIRMED TRANSP:OPAQUE DESCRIPTION:*** RRULE:FREQ=WEEKLY;UNTIL=20190703T215900Z;INTERVAL=2;WKST=MO;BYDAY=TU LAST-MODIFIED:20190115T194435Z DTSTAMP:20190115T194435Z SEQUENCE:2 CLASS:PUBLIC DTSTART;TZID=Europe/Zurich:20190115T194500 DTEND;TZID=Europe/Zurich:20190115T213000 UID:HB8RNNI9SJB5JIHD0FFSOG END:VEVENT BEGIN:VEVENT DTSTART;TZID=Europe/Zurich:20190129T194500 DESCRIPTION:*** /***/libs/ICal/ICal.php on line 2598 `

For some reasons this function processes the file CONTENT and not the FILENAME. I don't understand why, also I didn't touch the code at all. This patch simply suppresses the warning
